### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Lite³ is a zero-copy binary serialization format encoding data as a B-tree insi
 
 As a result, the serialization boundary has been broken: 'parsing' or 'serializing' in the traditional sense is no longer necessary. Lite³ structures can be read and mutated directly similar to hashmaps or binary trees, and since they exist in a single contiguous buffer, they always remain ready to send.
 
-Compared to other binary formats, Lite³ is schemaless, self-describing (no IDL or schema definitons required) and **supports conversion to/from JSON**, enabling compatibility with existing datasets/APIs and allowing for easy debugging/inspecting of messages.
+Compared to other binary formats, Lite³ is schemaless, self-describing (no IDL or schema definitions required) and **supports conversion to/from JSON**, enabling compatibility with existing datasets/APIs and allowing for easy debugging/inspecting of messages.
 
 Thanks to the cache-friendly properties of the B-tree and the very minimalistic C implementation (9.3 kB), Lite³ outperforms the fastest JSON libraries (that make use of SIMD) by up to 120x depending on the benchmark. It also outperforms schema-only formats, such as Google Flatbuffers (242x). Lite³ is possibly the fastest schemaless data format in the world.
 
@@ -30,7 +30,7 @@ However Lite³ blurs the line between memory and wire formats, allowing direct a
 
 
 ## Features
-- Schemaless & self-describing, no IDL or schema definitons required
+- Schemaless & self-describing, no IDL or schema definitions required
 - Zero-copy reads + writes of any data size
 - Lives on OSI layer 6 (transport/protocol agnostic)
 - O(log n) amortized time complexity for all IOPS
@@ -237,7 +237,7 @@ gcc -o main main.c -I/path/to/lite3/include /path/to/lite3/build/liblite3.a
 #### Choose your API
 The Buffer API provides the most control, utilizing caller-supplied buffers to support environments with custom allocation patterns, avoiding the use of `malloc()`.
 
-The Context API is a wrapper aound the Buffer API where memory allocations are hidden from the user, presenting a more accessible interface. If you are using Lite³ for the first time, it is recommmended to start with the Context API.
+The Context API is a wrapper around the Buffer API where memory allocations are hidden from the user, presenting a more accessible interface. If you are using Lite³ for the first time, it is recommended to start with the Context API.
 ```C
 #include "lite3.h"              // Buffer API
 #include "lite3_context_api.h"  // Context API
@@ -304,7 +304,7 @@ Remember that we judge the behavior of formats by their implementation rather th
 
 ## Benchmarks
 ### Simdjson Twitter API Data Benchmark
-This benchmark by the authors of [the official simdjson respository](https://github.com/simdjson/simdjson)
+This benchmark by the authors of [the official simdjson repository](https://github.com/simdjson/simdjson)
 was created to compare JSON parsing performance for different C/C++ libraries.
 
 An input dataset `twitter.json` is used, consisting ~632 kB of real twitter API data to perform a number of tasks, each having its own category:

--- a/include/lite3.h
+++ b/include/lite3.h
@@ -147,7 +147,7 @@ Enabled by default.
 This is a safety feature since not doing so would leave 'deleted' entries intact inside the datastructure until they are overwritten by other values.
 Disable if you do not care about leaking deleted data.
 
-@note When following canoncial encoding rules, features `LITE3_ZERO_MEM_DELETED` and `LITE3_ZERO_MEM_EXTRA` are required.
+@note When following canonical encoding rules, features `LITE3_ZERO_MEM_DELETED` and `LITE3_ZERO_MEM_EXTRA` are required.
 */
 #define LITE3_ZERO_MEM_DELETED
 
@@ -164,7 +164,7 @@ This is a safety feature to prevent leaking uninitialized memory bytes into mess
 It is also useful for debugging, as it makes the structure a lot more readable.
 If you plan to use compression, this option makes Lite³ structures achieve better compression ratios.
 
-@note When following canoncial encoding rules, features `LITE3_ZERO_MEM_DELETED` and `LITE3_ZERO_MEM_EXTRA` are required.
+@note When following canonical encoding rules, features `LITE3_ZERO_MEM_DELETED` and `LITE3_ZERO_MEM_EXTRA` are required.
 */
 #define LITE3_ZERO_MEM_EXTRA
 
@@ -632,7 +632,7 @@ Generational pointer / safe access wrapper
 
 Every Lite³ buffer stores a generation count which is incremented on every mutation.
 lite3_bytes accessed through the LITE3_BYTES() macro will return a direct pointer if `lite3_bytes.gen` matches the generation count of the buffer.
-Othewise, it returns NULL.
+Otherwise, it returns NULL.
 
 When a Lite³ structure is modified via `set()` or `delete()`, pointed to data could be moved or deleted;
 therefore it is no longer safe to dereference previously obtained pointers. This macro prevents dangerous situations with dangling pointers.
@@ -661,7 +661,7 @@ Generational pointer / safe access wrapper
 
 Every Lite³ buffer stores a generation count which is incremented on every mutation.
 lite3_str accessed through the LITE3_STR() macro will return a direct pointer if `lite3_str.gen` matches the generation count of the buffer.
-Othewise, it returns NULL.
+Otherwise, it returns NULL.
 
 When a Lite³ structure is modified via `set()` or `delete()`, pointed to data could be moved or deleted;
 therefore it is no longer safe to dereference previously obtained pointers. This macro prevents dangerous situations with dangling pointers.
@@ -1689,7 +1689,7 @@ Get functions read `buflen` to know the currently used portion of the buffer.
 The `ofs` (offset) field is used to target an object or array inside the Lite³ buffer. To target the root-level object/array, use `ofs == 0`.
 
 @warning
-Read-only operations are thread-safe. This includes all utility funtions. Mixing reads and writes however is not thread-safe.
+Read-only operations are thread-safe. This includes all utility functions. Mixing reads and writes however is not thread-safe.
 
 @defgroup lite3_utility Utility Functions
 @ingroup lite3_buffer_api
@@ -2109,7 +2109,7 @@ The `ofs` (offset) field is used to target an object or array inside the Lite³ 
 - Returns < 0 on error
 
 @warning
-Read-only operations are thread-safe. This includes all `lite3_get_xxx()` funtions. Mixing reads and writes however is not thread-safe.
+Read-only operations are thread-safe. This includes all `lite3_get_xxx()` functions. Mixing reads and writes however is not thread-safe.
 
 @defgroup lite3_get Object Get
 @ingroup lite3_buffer_api
@@ -2413,7 +2413,7 @@ The `ofs` (offset) field is used to target an object or array inside the Lite³ 
 - Returns < 0 on error
 
 @warning
-Read-only operations are thread-safe. This includes all `lite3_arr_get_xxx()` funtions. Mixing reads and writes however is not thread-safe.
+Read-only operations are thread-safe. This includes all `lite3_arr_get_xxx()` functions. Mixing reads and writes however is not thread-safe.
 
 @defgroup lite3_arr_get Array Get
 @ingroup lite3_buffer_api
@@ -2623,7 +2623,7 @@ Iter functions read `buflen` to know the currently used portion of the buffer.
 The `ofs` (offset) field is used to target an object or array inside the Lite³ buffer. To target the root-level object/array, use `ofs == 0`.
 
 @warning
-Read-only operations are thread-safe. This includes all iterator funtions. Mixing reads and writes however is not thread-safe.
+Read-only operations are thread-safe. This includes all iterator functions. Mixing reads and writes however is not thread-safe.
 
 @defgroup lite3_iter Iterators
 @ingroup lite3_buffer_api
@@ -2674,7 +2674,7 @@ static inline int lite3_iter_create(
 /**
 Get the next item from a lite3 iterator
 
-To use in conjunctions with @ref lite3_val_fns, the `*out_val_ofs` can be casted to `(lite3_val *)`.
+To use in conjunctions with @ref lite3_val_fns, the `*out_val_ofs` can be cast to `(lite3_val *)`.
 
 @return `LITE3_ITER_ITEM` (== 1) on item produced
 @return `LITE3_ITER_DONE` (== 0) on success (no more items)
@@ -2770,7 +2770,7 @@ static inline const char *lite3_val_str(lite3_val *val)
 
 /**
 @warning
-`*out_len` is exclusive of the  NULL-terminator.
+`*out_len` is exclusive of the NULL-terminator.
 */
 static inline const char *lite3_val_str_n(lite3_val *val, size_t *out_len)
 {
@@ -2814,7 +2814,7 @@ This feature requires subdependencies enabled via build flags. See the `Makefile
 Also `LITE3_JSON` must be defined inside the `lite3.h` header or using compiler `-D` flags. See @ref lite3_config.
 
 @warning
-Read-only operations are thread-safe. This includes all JSON encode funtions.
+Read-only operations are thread-safe. This includes all JSON encode functions.
 Decoding JSON however is not thread-safe for the given Lite³ buffer and requires manual locking.
 Mixing reads and writes on the same Lite³ buffer is also not thread-safe.
 

--- a/include/lite3_context_api.h
+++ b/include/lite3_context_api.h
@@ -188,7 +188,7 @@ lite3_ctx *lite3_ctx_create_from_buf(
 Create context by taking ownership of a buffer
 
 When you have an existing allocation containing a Lite³ message,
-you might want a context to to take ownership over it rather than copying all the data.
+you might want a context to take ownership over it rather than copying all the data.
 The passed buffer will also be freed when you call `lite3_ctx_destroy()` on the context later.
 
 @warning
@@ -1185,7 +1185,7 @@ Utility functions
 The `ofs` (offset) field is used to target an object or array inside the Lite³ buffer. To target the root-level object/array, use `ofs == 0`.
 
 @warning
-Read-only operations are thread-safe. This includes all utility funtions. Mixing reads and writes however is not thread-safe.
+Read-only operations are thread-safe. This includes all utility functions. Mixing reads and writes however is not thread-safe.
 
 @defgroup lite3_ctx_utility Utility Functions
 @ingroup lite3_context_api
@@ -1539,7 +1539,7 @@ The `ofs` (offset) field is used to target an object or array inside the Lite³ 
 - Returns < 0 on error
 
 @warning
-Read-only operations are thread-safe. This includes all `lite3_get_xxx()` funtions. Mixing reads and writes however is not thread-safe.
+Read-only operations are thread-safe. This includes all `lite3_get_xxx()` functions. Mixing reads and writes however is not thread-safe.
 
 @defgroup lite3_ctx_get Object Get
 @ingroup lite3_context_api
@@ -1832,7 +1832,7 @@ The `ofs` (offset) field is used to target an object or array inside the Lite³ 
 - Returns < 0 on error
 
 @warning
-Read-only operations are thread-safe. This includes all `lite3_arr_get_xxx()` funtions. Mixing reads and writes however is not thread-safe.
+Read-only operations are thread-safe. This includes all `lite3_arr_get_xxx()` functions. Mixing reads and writes however is not thread-safe.
 
 @defgroup lite3_ctx_arr_get Array Get
 @ingroup lite3_context_api
@@ -2033,7 +2033,7 @@ Create and use iterators for objects/arrays
 The `ofs` (offset) field is used to target an object or array inside the Lite³ buffer. To target the root-level object/array, use `ofs == 0`.
 
 @warning
-Read-only operations are thread-safe. This includes all iterator funtions. Mixing reads and writes however is not thread-safe.
+Read-only operations are thread-safe. This includes all iterator functions. Mixing reads and writes however is not thread-safe.
 
 @defgroup lite3_ctx_iter Iterators
 @ingroup lite3_context_api
@@ -2066,7 +2066,7 @@ static inline int lite3_ctx_iter_create(
 /**
 Get the next item from a lite3 iterator
 
-To use in conjunctions with @ref lite3_val_fns, the `*out_val_ofs` can be casted to `(lite3_val *)`.
+To use in conjunctions with @ref lite3_val_fns, the `*out_val_ofs` can be cast to `(lite3_val *)`.
 
 @return `LITE3_ITER_ITEM` (== 1) on item produced
 @return `LITE3_ITER_DONE` (== 0) on success (no more items)
@@ -2112,7 +2112,7 @@ This feature requires subdependencies enabled via build flags. See the `Makefile
 Also `LITE3_JSON` must be defined inside the `lite3.h` header or using compiler `-D` flags. See @ref lite3_config.
 
 @warning
-Read-only operations are thread-safe. This includes all JSON encode funtions.
+Read-only operations are thread-safe. This includes all JSON encode functions.
 Decoding JSON however is not thread-safe for the given Lite³ buffer and requires manual locking.
 Mixing reads and writes on the same Lite³ buffer is also not thread-safe.
 

--- a/src/json_dec.c
+++ b/src/json_dec.c
@@ -83,7 +83,7 @@ int _lite3_json_dec_obj_switch(unsigned char *buf, size_t *restrict inout_buflen
                                         return ret;
                                 break;
                         } else {
-                                if ((ret = lite3_set_f64(buf, inout_buflen, ofs, bufsz, key, (double)num_u64)) < 0) // Number to big for (signed) int64_t, fall back to double
+                                if ((ret = lite3_set_f64(buf, inout_buflen, ofs, bufsz, key, (double)num_u64)) < 0) // Number too big for (signed) int64_t, fall back to double
                                         return ret;
                                 break;
                         }
@@ -165,7 +165,7 @@ int _lite3_json_dec_arr_switch(unsigned char *buf, size_t *restrict inout_buflen
                                         return ret;
                                 break;
                         } else {
-                                if ((ret = lite3_arr_append_f64(buf, inout_buflen, ofs, bufsz, (double)num_u64)) < 0) // Number to big for (signed) int64_t, fall back to double
+                                if ((ret = lite3_arr_append_f64(buf, inout_buflen, ofs, bufsz, (double)num_u64)) < 0) // Number too big for (signed) int64_t, fall back to double
                                         return ret;
                                 break;
                         }

--- a/src/lite3.c
+++ b/src/lite3.c
@@ -230,7 +230,7 @@ int lite3_get_impl(
 	} else if (*(buf + ofs) == LITE3_TYPE_ARRAY) {
 		LITE3_PRINT_DEBUG("GET\tindex: %u\n", key_data.hash);
 	} else {
-		LITE3_PRINT_DEBUG("GET INVALID: EXEPCTING ARRAY OR OBJECT TYPE\n");
+		LITE3_PRINT_DEBUG("GET INVALID: EXPECTING ARRAY OR OBJECT TYPE\n");
 	}
 	#endif
 
@@ -384,7 +384,7 @@ int lite3_iter_next(const unsigned char *buf, size_t buflen, lite3_iter *iter, l
 
 	enum lite3_type type = node->gen_type & LITE3_NODE_TYPE_MASK;
 	if (LITE3_UNLIKELY(!(type == LITE3_TYPE_OBJECT || type == LITE3_TYPE_ARRAY))) {
-		LITE3_PRINT_ERROR("INVALID ARGUMENT: EXPECTING ARRAY ORlite3_iter_nex OBJECT TYPE\n");
+		LITE3_PRINT_ERROR("INVALID ARGUMENT: EXPECTING ARRAY OR OBJECT TYPE\n");
 		errno = EINVAL;
 		return -1;
 	}
@@ -530,7 +530,7 @@ int lite3_set_impl(
 	} else if (*(buf + ofs) == LITE3_TYPE_ARRAY) {
 		LITE3_PRINT_DEBUG("SET\tindex: %u\n", key_data.hash);
 	} else {
-		LITE3_PRINT_DEBUG("SET INVALID: EXEPCTING ARRAY OR OBJECT TYPE\n");
+		LITE3_PRINT_DEBUG("SET INVALID: EXPECTING ARRAY OR OBJECT TYPE\n");
 	}
 	#endif
 


### PR DESCRIPTION
I saw some typos when reading the headers and decided to throw my tool at it to fix them. 
I reviewed all the fixes and they look good to me.

Please review carefully the error string in lite3.c, as it seems an unwanted paste made its way into the string, so there might also be additional semantic error there.

Notes: "cast" is one of those irregular verbs where the passive form is the same as the infinitive.
